### PR TITLE
Fixing UG_RESULT type to avoid warnings

### DIFF
--- a/ugui.h
+++ b/ugui.h
@@ -113,7 +113,7 @@ typedef struct
  */
 typedef struct S_OBJECT UG_OBJECT;
 typedef struct S_WINDOW UG_WINDOW;
-typedef UG_S8 UG_RESULT;
+typedef UG_U8 UG_RESULT;
 #ifdef USE_COLOR_RGB888
 typedef UG_U32 UG_COLOR;
 #endif


### PR DESCRIPTION
[140579](https://stonepagamentos.visualstudio.com/Tribo%20Meios%20de%20Pagamento/_workitems/edit/140579)

* Precisei modificar uma macro por causa de incompatibilidade de tipos. Basicamente estavam ocorrendo comparações entre signed e unsigned char, que estava gerando warnings e quebrando o build. Em algumas condições estava causando a condição ser sempre falsa por comparar com um valor que estava fora do domínio da variável.