### PR TITLE
Removing hardcoded color format. I must be defined in mambaloader build

### DIFF
--- a/ugui_config.h
+++ b/ugui_config.h
@@ -10,7 +10,7 @@
 //#define USE_MULTITASKING
 
 /* Enable color mode */
-#define USE_COLOR_RGB888 // RGB = 0xFF,0xFF,0xFF
+//#define USE_COLOR_RGB888 // RGB = 0xFF,0xFF,0xFF
 //#define USE_COLOR_RGB565   // RGB = 0bRRRRRGGGGGGBBBBB
 
 /* Enable needed fonts here */


### PR DESCRIPTION
## Description
[151210](https://stonepagamentos.visualstudio.com/Tribo%20Meios%20de%20Pagamento/_workitems/edit/151210)
  
## Big picture
Removing da UGUI o formato de cores marretado no código. Agora o build do mambaloader decide que formato definir baseado na plataforma target